### PR TITLE
FIX: account for spaces in setting

### DIFF
--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -22,7 +22,9 @@ export default class CategoriesGroups extends Component {
   get categoryGroupList() {
     const buildCategoryGroup = (obj, foundCategories) => {
       return this.categories.filter((category) => {
-        const categoryArray = obj.categories.split(",");
+        const categoryArray = obj.categories
+          .split(",")
+          .map((str) => str.trim());
         if (categoryArray.includes(category.slug) && !category.hasMuted) {
           foundCategories.push(category.slug);
           return true;


### PR DESCRIPTION
follow-up to `47149ab`

spaces in the setting were breaking this for subsequent categories, so this trims them out 