### PR TITLE
DEV: update for refactored discovery route

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -168,6 +168,7 @@
   }
 }
 
+.navigation-categories .contents .category-boxes-with-topics,
 .navigation-categories .contents .category-boxes {
   // hides the default categories layout on desktop, so the custom layout appears
   display: none;

--- a/javascripts/discourse/components/categories-groups.hbs
+++ b/javascripts/discourse/components/categories-groups.hbs
@@ -1,128 +1,130 @@
 {{#if this.shouldShow}}
-  <div
-    class="custom-categories-groups"
-    {{did-insert this.initializeLocalStorage}}
-  >
-    {{#each categoryGroupList as |t|}}
-      <div class="custom-category-group-{{dasherize t.name}} is-expanded">
-        <a
-          id={{dasherize t.name}}
-          class="custom-category-group-toggle"
-          href
-          {{action "toggleCategories" t.name}}
-        >
-          <h2>{{t.name}}</h2>
-          {{d-icon "angle-right"}}
-        </a>
+  <section class="category-boxes with-logos with-subcategories">
+    <div
+      class="custom-categories-groups"
+      {{did-insert this.initializeLocalStorage}}
+    >
+      {{#each categoryGroupList as |t|}}
+        <div class="custom-category-group-{{dasherize t.name}} is-expanded">
+          <a
+            id={{dasherize t.name}}
+            class="custom-category-group-toggle"
+            href
+            {{action "toggleCategories" t.name}}
+          >
+            <h2>{{t.name}}</h2>
+            {{d-icon "angle-right"}}
+          </a>
 
-        <ul class="custom-category-group">
-          {{#each t.categories as |c|}}
-            <PluginOutlet
-              @name="category-box-before-each-box"
-              @outletArgs={{hash category=c}}
-            />
+          <ul class="custom-category-group">
+            {{#each t.categories as |c|}}
+              <PluginOutlet
+                @name="category-box-before-each-box"
+                @outletArgs={{hash category=c}}
+              />
 
-            {{! modified version of the core categories-boxes layout }}
-            <li
-              style={{unless noCategoryStyle (border-color c.color)}}
-              data-category-id={{c.id}}
-              data-notification-level={{c.notificationLevelString}}
-              data-url={{c.url}}
-              class="category category-box category-box-{{c.slug}}
-                {{if c.isMuted 'muted'}}
-                {{if noCategoryStyle 'no-category-boxes-style'}}"
-            >
-              <div class="category-box-inner">
-                <div class="category-logo">
-                  {{#if c.uploaded_logo.url}}
-                    <CategoryLogo @category={{c}} />
-                  {{/if}}
-                </div>
-                <div class="category-details">
-                  <div class="category-box-heading">
-                    <a class="parent-box-link" href={{c.url}}>
-                      <h3>
-                        {{category-title-before category=c}}
-                        {{#if c.read_restricted}}
-                          {{d-icon "lock"}}
-                        {{/if}}
-                        {{c.name}}
-                      </h3>
-                    </a>
+              {{! modified version of the core categories-boxes layout }}
+              <li
+                style={{unless noCategoryStyle (border-color c.color)}}
+                data-category-id={{c.id}}
+                data-notification-level={{c.notificationLevelString}}
+                data-url={{c.url}}
+                class="category category-box category-box-{{c.slug}}
+                  {{if c.isMuted 'muted'}}
+                  {{if noCategoryStyle 'no-category-boxes-style'}}"
+              >
+                <div class="category-box-inner">
+                  <div class="category-logo">
+                    {{#if c.uploaded_logo.url}}
+                      <CategoryLogo @category={{c}} />
+                    {{/if}}
                   </div>
-
-                  <div class="description">
-                    {{html-safe c.description_excerpt}}
-                  </div>
-                  {{#if c.isGrandParent}}
-                    {{#each c.subcategories as |subcategory|}}
-                      <div
-                        data-category-id={{subcategory.id}}
-                        data-notification-level={{subcategory.notificationLevelString}}
-                        style={{border-color subcategory.color}}
-                        class="subcategory with-subcategories
-                          {{if
-                            subcategory.uploaded_logo.url
-                            'has-logo'
-                            'no-logo'
-                          }}"
-                      >
-                        <div class="subcategory-box-inner">
-                          {{category-title-link
-                            tagName="h4"
-                            category=subcategory
-                          }}
-                          {{#if subcategory.subcategories}}
-                            <div class="subcategories">
-                              {{#each
-                                subcategory.subcategories
-                                as |subsubcategory|
-                              }}
-                                {{#unless subsubcategory.isMuted}}
-                                  <span class="subcategory">
-                                    {{category-title-before
-                                      category=subsubcategory
-                                    }}
-                                    {{category-link
-                                      subsubcategory
-                                      hideParent="true"
-                                    }}
-                                  </span>
-                                {{/unless}}
-                              {{/each}}
-                            </div>
+                  <div class="category-details">
+                    <div class="category-box-heading">
+                      <a class="parent-box-link" href={{c.url}}>
+                        <h3>
+                          {{category-title-before category=c}}
+                          {{#if c.read_restricted}}
+                            {{d-icon "lock"}}
                           {{/if}}
-                        </div>
-                      </div>
-                    {{/each}}
-                  {{else if c.subcategories}}
-                    <div class="subcategories">
-                      {{#each c.subcategories as |sc|}}
-                        <a class="subcategory" href={{sc.url}}>
-                          <span class="subcategory-image-placeholder">
-                            {{cdn-img
-                              src=sc.uploaded_logo.url
-                              class="logo"
-                              width=sc.uploaded_logo.width
-                              height=sc.uploaded_logo.height
-                              alt=""
-                            }}
-                          </span>
-                          {{category-link sc hideParent="true"}}
-                        </a>
-                      {{/each}}
+                          {{c.name}}
+                        </h3>
+                      </a>
                     </div>
-                  {{/if}}
+
+                    <div class="description">
+                      {{html-safe c.description_excerpt}}
+                    </div>
+                    {{#if c.isGrandParent}}
+                      {{#each c.subcategories as |subcategory|}}
+                        <div
+                          data-category-id={{subcategory.id}}
+                          data-notification-level={{subcategory.notificationLevelString}}
+                          style={{border-color subcategory.color}}
+                          class="subcategory with-subcategories
+                            {{if
+                              subcategory.uploaded_logo.url
+                              'has-logo'
+                              'no-logo'
+                            }}"
+                        >
+                          <div class="subcategory-box-inner">
+                            {{category-title-link
+                              tagName="h4"
+                              category=subcategory
+                            }}
+                            {{#if subcategory.subcategories}}
+                              <div class="subcategories">
+                                {{#each
+                                  subcategory.subcategories
+                                  as |subsubcategory|
+                                }}
+                                  {{#unless subsubcategory.isMuted}}
+                                    <span class="subcategory">
+                                      {{category-title-before
+                                        category=subsubcategory
+                                      }}
+                                      {{category-link
+                                        subsubcategory
+                                        hideParent="true"
+                                      }}
+                                    </span>
+                                  {{/unless}}
+                                {{/each}}
+                              </div>
+                            {{/if}}
+                          </div>
+                        </div>
+                      {{/each}}
+                    {{else if c.subcategories}}
+                      <div class="subcategories">
+                        {{#each c.subcategories as |sc|}}
+                          <a class="subcategory" href={{sc.url}}>
+                            <span class="subcategory-image-placeholder">
+                              {{cdn-img
+                                src=sc.uploaded_logo.url
+                                class="logo"
+                                width=sc.uploaded_logo.width
+                                height=sc.uploaded_logo.height
+                                alt=""
+                              }}
+                            </span>
+                            {{category-link sc hideParent="true"}}
+                          </a>
+                        {{/each}}
+                      </div>
+                    {{/if}}
+                  </div>
+                  <PluginOutlet
+                    @name="category-box-below-each-category"
+                    @outletArgs={{hash category=c}}
+                  />
                 </div>
-                <PluginOutlet
-                  @name="category-box-below-each-category"
-                  @outletArgs={{hash category=c}}
-                />
-              </div>
-            </li>
-          {{/each}}
-        </ul>
-      </div>
-    {{/each}}
-  </div>
+              </li>
+            {{/each}}
+          </ul>
+        </div>
+      {{/each}}
+    </div>
+  </section>
 {{/if}}

--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -13,10 +13,16 @@ function parseSettings(settings) {
 
 export default class CategoriesGroups extends Component {
   @service router;
+  @service siteSettings;
 
   get shouldShow() {
-    // we don't want this to show for subcategories within category routes
-    return this.router.currentRouteName === "discovery.categories";
+    const currentRoute = this.router.currentRouteName;
+    const categoryPageStyle = this.siteSettings.desktop_category_page_style;
+
+    return (
+      currentRoute === "discovery.categories" &&
+      categoryPageStyle.includes("boxes")
+    );
   }
 
   get categoryGroupList() {

--- a/javascripts/discourse/connectors/above-discovery-categories/custom-categories-boxes.hbs
+++ b/javascripts/discourse/connectors/above-discovery-categories/custom-categories-boxes.hbs
@@ -1,11 +1,8 @@
 {{#if
   (or
-    (eq categoryPageStyle "categories-boxes")
+    (not this.site.mobileView)
     (and (theme-setting "show_on_mobile") this.site.mobileView)
   )
 }}
-
-  <section class="category-boxes with-logos with-subcategories">
-    <CategoriesGroups @categories={{this.outletArgs.categories.content}} />
-  </section>
+  <CategoriesGroups @categories={{this.outletArgs.categories.content}} />
 {{/if}}

--- a/javascripts/discourse/connectors/above-discovery-categories/custom-categories-boxes.hbs
+++ b/javascripts/discourse/connectors/above-discovery-categories/custom-categories-boxes.hbs
@@ -1,6 +1,6 @@
 {{#if
   (or
-    (not this.site.mobileView)
+    this.site.desktopView
     (and (theme-setting "show_on_mobile") this.site.mobileView)
   )
 }}


### PR DESCRIPTION
After the core refactor (https://github.com/discourse/discourse/commit/82d6d691eec9e97c88d67182bcbc583461e3e0dc), `categoryPageStyle` is no longer available from the outlet, so I check `siteSettings` in the `shouldShow` getter instead. 

This required moving the `section` wrapper from the outlet to the component as well. 

This should also be backwards compatible. 