### PR TITLE
UX: include gap for subcategories

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -33,6 +33,7 @@
     }
 
     .subcategories {
+      gap: 0 0.5em;
       margin-top: auto;
     }
   }


### PR DESCRIPTION
Before:
![image](https://github.com/discourse/discourse-category-groups-component/assets/1681963/baa68892-1360-430d-beb3-9000c9195b56)


After:
![image](https://github.com/discourse/discourse-category-groups-component/assets/1681963/06a03d84-2377-4416-8a33-2212b4bcb111)
