### PR TITLE
FIX: do not include categories in both ungrouped and muted lists

### DIFF
--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -49,7 +49,7 @@ export default class CategoriesGroups extends Component {
       return groups;
     }, []);
     const ungroupedCategories = this.categories.filter(
-      (c) => !foundCategories.includes(c.slug)
+      (c) => !foundCategories.includes(c.slug) && c.notification_level !== 0
     );
     const mutedCategories = this.categories.filterBy("hasMuted");
 


### PR DESCRIPTION
Before:
![image](https://github.com/discourse/discourse-category-groups-component/assets/1681963/b3ef2c17-cf98-41c9-8e2f-2c98bb03101a)


After:
![image](https://github.com/discourse/discourse-category-groups-component/assets/1681963/7df74ca8-2796-405e-a30a-7d4224bed5f2)
