### PR TITLE
UX: add setting to hide muted subcategories from list when parent is unmuted

### DIFF
--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -51,7 +51,10 @@ export default class CategoriesGroups extends Component {
     const ungroupedCategories = this.categories.filter(
       (c) => !foundCategories.includes(c.slug) && c.notification_level !== 0
     );
-    const mutedCategories = this.categories.filterBy("hasMuted");
+
+    const mutedCategories = settings.hide_muted_subcategories
+      ? this.categories.filter((c) => c.notification_level === 0)
+      : this.categories.filterBy("hasMuted");
 
     if (settings.show_ungrouped && ungroupedCategories.length > 0) {
       categoryGroupList.push({

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,5 +5,6 @@ en:
       category_groups: "Format as: Group name: category-slug, category-slug-2"
       show_on_mobile: "Show the collapsible category box groups on mobile"
       show_ungrouped: "Display a group of categories that aren't assigned to another group"
+      hide_muted_subcategories: "When enabled, a non-muted parent category will not appear under the muted section if it has a muted subcategory"
       fancy_styling: "Turn on additional styling"
   ungrouped_categories_title: "Other"

--- a/settings.yml
+++ b/settings.yml
@@ -10,3 +10,6 @@ show_ungrouped:
 
 fancy_styling:
   default: false
+
+hide_muted_subcategories:
+  default: false


### PR DESCRIPTION
By default in Discourse, we filter muted categories on the /categories route using 

`this.categories.filterBy("hasMuted")`

This means that when a parent category is not muted, but a subcategory is muted, we list the category as usual AND also duplicate it under the "muted" section to show that it has a muted subcategory. 

![muted](https://github.com/discourse/discourse-category-groups-component/assets/1681963/85eaac96-6a27-42e5-af8f-371a66f29964)


This isn't always desirable, especially when a categories layout doesn't list subcategories, so I've added a setting to instead filter by the parent notification level, which prevents this behavior. 


![image](https://github.com/discourse/discourse-category-groups-component/assets/1681963/c708ceb3-6462-49e8-aabe-e60209ecd3e0)

