### PR TITLE
FIX: better sanitize group names

### DIFF
--- a/javascripts/discourse/components/categories-groups.hbs
+++ b/javascripts/discourse/components/categories-groups.hbs
@@ -6,11 +6,11 @@
     >
       {{#each categoryGroupList as |t|}}
         <div
-          class="custom-category-group-{{this.sanitizeIdentifier t.name}}
+          class="custom-category-group-{{this.slugifyIdentifier t.name}}
             is-expanded"
         >
           <a
-            id={{this.sanitizeIdentifier t.name}}
+            id={{this.slugifyIdentifier t.name}}
             class="custom-category-group-toggle"
             href
             {{action "toggleCategories" t.name}}

--- a/javascripts/discourse/components/categories-groups.hbs
+++ b/javascripts/discourse/components/categories-groups.hbs
@@ -5,9 +5,12 @@
       {{did-insert this.initializeLocalStorage}}
     >
       {{#each categoryGroupList as |t|}}
-        <div class="custom-category-group-{{dasherize t.name}} is-expanded">
+        <div
+          class="custom-category-group-{{this.sanitizeIdentifier t.name}}
+            is-expanded"
+        >
           <a
-            id={{dasherize t.name}}
+            id={{this.sanitizeIdentifier t.name}}
             class="custom-category-group-toggle"
             href
             {{action "toggleCategories" t.name}}

--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import { slugify } from "discourse/lib/utilities";
 import I18n from "I18n";
 
 function parseSettings(settings) {
@@ -71,7 +72,7 @@ export default class CategoriesGroups extends Component {
 
   @action
   toggleCategories(e) {
-    const id = this.sanitizeIdentifier(e);
+    const id = slugify(e);
     const storedCategories =
       JSON.parse(localStorage.getItem("categoryGroups")) || [];
     const categoryClass = `.custom-category-group-${id}`;
@@ -103,11 +104,7 @@ export default class CategoriesGroups extends Component {
   }
 
   @action
-  sanitizeIdentifier(str) {
-    return str
-      .replace(/[^a-zA-Z0-9-_]/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .replace(/-+/g, "-")
-      .toLowerCase();
+  slugifyIdentifier(str) {
+    return slugify(str);
   }
 }

--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -1,7 +1,6 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { dasherize } from "@ember/string";
 import I18n from "I18n";
 
 function parseSettings(settings) {
@@ -72,7 +71,7 @@ export default class CategoriesGroups extends Component {
 
   @action
   toggleCategories(e) {
-    const id = dasherize(e);
+    const id = this.sanitizeIdentifier(e);
     const storedCategories =
       JSON.parse(localStorage.getItem("categoryGroups")) || [];
     const categoryClass = `.custom-category-group-${id}`;
@@ -101,5 +100,14 @@ export default class CategoriesGroups extends Component {
     storedCategories.forEach((category) => {
       document.querySelector(category)?.classList.remove("is-expanded");
     });
+  }
+
+  @action
+  sanitizeIdentifier(str) {
+    return str
+      .replace(/[^a-zA-Z0-9-_]/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .replace(/-+/g, "-")
+      .toLowerCase();
   }
 }


### PR DESCRIPTION
If you try to create a group name with an ampersand or other special character, it would break the ability to collapse a group — this adds a sanitizer that's more comprehensive than dasherizer to avoid the issue.  