### PR TITLE
FEATURE: Ability to render extra links mixed in with categories

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -49,6 +49,22 @@
   .subcategories .subcategory .subcategory-image-placeholder {
     margin: 0;
   }
+
+  // Extra link styling
+  .extra-link.category-box {
+    .parent-box-link {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      color: var(--primary);
+      margin-top: 0.25em;
+      margin-bottom: 0.5em;
+
+      .title {
+        margin: 0;
+      }
+    }
+  }
 }
 
 .custom-category-group-toggle {

--- a/javascripts/discourse/components/categories-groups.hbs
+++ b/javascripts/discourse/components/categories-groups.hbs
@@ -20,110 +20,114 @@
           </a>
 
           <ul class="custom-category-group">
-            {{#each t.categories as |c|}}
-              <PluginOutlet
-                @name="category-box-before-each-box"
-                @outletArgs={{hash category=c}}
-              />
+            {{#each t.items as |c|}}
+              {{#if c.isExtraLink}}
+                <CategoryGroupExtraLink @link={{c}} />
+              {{else}}
+                <PluginOutlet
+                  @name="category-box-before-each-box"
+                  @outletArgs={{hash category=c}}
+                />
 
-              {{! modified version of the core categories-boxes layout }}
-              <li
-                style={{unless noCategoryStyle (border-color c.color)}}
-                data-category-id={{c.id}}
-                data-notification-level={{c.notificationLevelString}}
-                data-url={{c.url}}
-                class="category category-box category-box-{{c.slug}}
-                  {{if c.isMuted 'muted'}}
-                  {{if noCategoryStyle 'no-category-boxes-style'}}"
-              >
-                <div class="category-box-inner">
-                  <div class="category-logo">
-                    {{#if c.uploaded_logo.url}}
-                      <CategoryLogo @category={{c}} />
-                    {{/if}}
-                  </div>
-                  <div class="category-details">
-                    <div class="category-box-heading">
-                      <a class="parent-box-link" href={{c.url}}>
-                        <h3>
-                          {{category-title-before category=c}}
-                          {{#if c.read_restricted}}
-                            {{d-icon "lock"}}
-                          {{/if}}
-                          {{c.name}}
-                        </h3>
-                      </a>
+                {{! modified version of the core categories-boxes layout }}
+                <li
+                  style={{unless noCategoryStyle (border-color c.color)}}
+                  data-category-id={{c.id}}
+                  data-notification-level={{c.notificationLevelString}}
+                  data-url={{c.url}}
+                  class="category category-box category-box-{{c.slug}}
+                    {{if c.isMuted 'muted'}}
+                    {{if noCategoryStyle 'no-category-boxes-style'}}"
+                >
+                  <div class="category-box-inner">
+                    <div class="category-logo">
+                      {{#if c.uploaded_logo.url}}
+                        <CategoryLogo @category={{c}} />
+                      {{/if}}
                     </div>
-
-                    <div class="description">
-                      {{html-safe c.description_excerpt}}
-                    </div>
-                    {{#if c.isGrandParent}}
-                      {{#each c.subcategories as |subcategory|}}
-                        <div
-                          data-category-id={{subcategory.id}}
-                          data-notification-level={{subcategory.notificationLevelString}}
-                          style={{border-color subcategory.color}}
-                          class="subcategory with-subcategories
-                            {{if
-                              subcategory.uploaded_logo.url
-                              'has-logo'
-                              'no-logo'
-                            }}"
-                        >
-                          <div class="subcategory-box-inner">
-                            {{category-title-link
-                              tagName="h4"
-                              category=subcategory
-                            }}
-                            {{#if subcategory.subcategories}}
-                              <div class="subcategories">
-                                {{#each
-                                  subcategory.subcategories
-                                  as |subsubcategory|
-                                }}
-                                  {{#unless subsubcategory.isMuted}}
-                                    <span class="subcategory">
-                                      {{category-title-before
-                                        category=subsubcategory
-                                      }}
-                                      {{category-link
-                                        subsubcategory
-                                        hideParent="true"
-                                      }}
-                                    </span>
-                                  {{/unless}}
-                                {{/each}}
-                              </div>
+                    <div class="category-details">
+                      <div class="category-box-heading">
+                        <a class="parent-box-link" href={{c.url}}>
+                          <h3>
+                            {{category-title-before category=c}}
+                            {{#if c.read_restricted}}
+                              {{d-icon "lock"}}
                             {{/if}}
-                          </div>
-                        </div>
-                      {{/each}}
-                    {{else if c.subcategories}}
-                      <div class="subcategories">
-                        {{#each c.subcategories as |sc|}}
-                          <a class="subcategory" href={{sc.url}}>
-                            <span class="subcategory-image-placeholder">
-                              {{cdn-img
-                                src=sc.uploaded_logo.url
-                                class="logo"
-                                width=sc.uploaded_logo.width
-                                height=sc.uploaded_logo.height
-                                alt=""
-                              }}
-                            </span>
-                            {{category-link sc hideParent="true"}}
-                          </a>
-                        {{/each}}
+                            {{c.name}}
+                          </h3>
+                        </a>
                       </div>
-                    {{/if}}
+
+                      <div class="description">
+                        {{html-safe c.description_excerpt}}
+                      </div>
+                      {{#if c.isGrandParent}}
+                        {{#each c.subcategories as |subcategory|}}
+                          <div
+                            data-category-id={{subcategory.id}}
+                            data-notification-level={{subcategory.notificationLevelString}}
+                            style={{border-color subcategory.color}}
+                            class="subcategory with-subcategories
+                              {{if
+                                subcategory.uploaded_logo.url
+                                'has-logo'
+                                'no-logo'
+                              }}"
+                          >
+                            <div class="subcategory-box-inner">
+                              {{category-title-link
+                                tagName="h4"
+                                category=subcategory
+                              }}
+                              {{#if subcategory.subcategories}}
+                                <div class="subcategories">
+                                  {{#each
+                                    subcategory.subcategories
+                                    as |subsubcategory|
+                                  }}
+                                    {{#unless subsubcategory.isMuted}}
+                                      <span class="subcategory">
+                                        {{category-title-before
+                                          category=subsubcategory
+                                        }}
+                                        {{category-link
+                                          subsubcategory
+                                          hideParent="true"
+                                        }}
+                                      </span>
+                                    {{/unless}}
+                                  {{/each}}
+                                </div>
+                              {{/if}}
+                            </div>
+                          </div>
+                        {{/each}}
+                      {{else if c.subcategories}}
+                        <div class="subcategories">
+                          {{#each c.subcategories as |sc|}}
+                            <a class="subcategory" href={{sc.url}}>
+                              <span class="subcategory-image-placeholder">
+                                {{cdn-img
+                                  src=sc.uploaded_logo.url
+                                  class="logo"
+                                  width=sc.uploaded_logo.width
+                                  height=sc.uploaded_logo.height
+                                  alt=""
+                                }}
+                              </span>
+                              {{category-link sc hideParent="true"}}
+                            </a>
+                          {{/each}}
+                        </div>
+                      {{/if}}
+                    </div>
+                    <PluginOutlet
+                      @name="category-box-below-each-category"
+                      @outletArgs={{hash category=c}}
+                    />
                   </div>
-                  <PluginOutlet
-                    @name="category-box-below-each-category"
-                    @outletArgs={{hash category=c}}
-                  />
-                </div>
-              </li>
+                </li>
+              {{/if}}
             {{/each}}
           </ul>
         </div>

--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -14,6 +14,7 @@ function parseSettings(settings) {
 const ExtraLink = class {
   constructor(args) {
     this.isExtraLink = true;
+    this.id = args.id;
     this.url = args.url;
     this.color = args.color;
     this.title = args.title;

--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -11,6 +11,17 @@ function parseSettings(settings) {
   });
 }
 
+const ExtraLink = class {
+  constructor(args) {
+    this.isExtraLink = true;
+    this.url = args.url;
+    this.color = args.color;
+    this.title = args.title;
+    this.description = args.description;
+    this.icon = args.icon;
+  }
+};
+
 export default class CategoriesGroups extends Component {
   @service router;
   @service siteSettings;
@@ -26,32 +37,51 @@ export default class CategoriesGroups extends Component {
   }
 
   get categoryGroupList() {
-    const buildCategoryGroup = (obj, foundCategories) => {
-      return this.categories.filter((category) => {
-        const categoryArray = obj.categories
-          .split(",")
-          .map((str) => str.trim());
-        if (categoryArray.includes(category.slug) && !category.hasMuted) {
-          foundCategories.push(category.slug);
-          return true;
-        }
-        return false;
-      });
-    };
-
     const parsedSettings = parseSettings(settings.category_groups);
+    const extraLinks = JSON.parse(settings.extra_links || "[]");
+
+    // Initialize an array to keep track of found categories and used links
     const foundCategories = [];
+    const usedLinks = [];
+
+    // Helper function to find extra link by ID
+    const findExtraLinkById = (id) => extraLinks.find((link) => link.id === id);
+
+    // Iterate through parsed settings in the defined order
     const categoryGroupList = parsedSettings.reduce((groups, obj) => {
-      const categoryGroup = buildCategoryGroup(obj, foundCategories);
+      const categoryArray = obj.categories.split(",").map((str) => str.trim());
+      const categoryGroup = [];
+
+      // Iterate through each category/link in the order specified in settings
+      categoryArray.forEach((categoryOrLinkId) => {
+        const category = this.categories.find(
+          (cat) => cat.slug === categoryOrLinkId && !cat.hasMuted
+        );
+
+        if (category) {
+          categoryGroup.push(category);
+          foundCategories.push(category.slug);
+        } else {
+          const extraLink = findExtraLinkById(categoryOrLinkId);
+          if (extraLink) {
+            categoryGroup.push(new ExtraLink(extraLink));
+            usedLinks.push(extraLink.id);
+          }
+        }
+      });
+
       if (categoryGroup.length > 0) {
-        groups.push({ name: obj.categoryGroup, categories: categoryGroup });
+        groups.push({ name: obj.categoryGroup, items: categoryGroup });
       }
       return groups;
     }, []);
+
+    // Find ungrouped categories
     const ungroupedCategories = this.categories.filter(
       (c) => !foundCategories.includes(c.slug) && c.notification_level !== 0
     );
 
+    // Find muted categories
     const mutedCategories = settings.hide_muted_subcategories
       ? this.categories.filter((c) => c.notification_level === 0)
       : this.categories.filterBy("hasMuted");
@@ -59,12 +89,12 @@ export default class CategoriesGroups extends Component {
     if (settings.show_ungrouped && ungroupedCategories.length > 0) {
       categoryGroupList.push({
         name: I18n.t(themePrefix("ungrouped_categories_title")),
-        categories: ungroupedCategories,
+        items: ungroupedCategories,
       });
     }
 
     if (mutedCategories.length > 0) {
-      categoryGroupList.push({ name: "muted", categories: mutedCategories });
+      categoryGroupList.push({ name: "muted", items: mutedCategories });
     }
 
     return categoryGroupList;

--- a/javascripts/discourse/components/category-group-extra-link.gjs
+++ b/javascripts/discourse/components/category-group-extra-link.gjs
@@ -9,7 +9,10 @@ export default class CategoryGroupExtraLink extends Component {
     return this.args.link.color.slice(1);
   }
   <template>
-    <li style={{borderColor this.borderColor}} class="extra-link category-box extra-link-{{@link.id}}">
+    <li
+      style={{borderColor this.borderColor}}
+      class="extra-link category-box extra-link-{{@link.id}}"
+    >
       <div class="category-box-inner">
         <div class="category-details">
           <div class="category-box-heading">

--- a/javascripts/discourse/components/category-group-extra-link.gjs
+++ b/javascripts/discourse/components/category-group-extra-link.gjs
@@ -9,7 +9,7 @@ export default class CategoryGroupExtraLink extends Component {
     return this.args.link.color.slice(1);
   }
   <template>
-    <li style={{borderColor this.borderColor}} class="extra-link category-box">
+    <li style={{borderColor this.borderColor}} class="extra-link category-box extra-link-{{@link.id}}">
       <div class="category-box-inner">
         <div class="category-details">
           <div class="category-box-heading">

--- a/javascripts/discourse/components/category-group-extra-link.gjs
+++ b/javascripts/discourse/components/category-group-extra-link.gjs
@@ -1,0 +1,31 @@
+import Component from "@glimmer/component";
+import { htmlSafe } from "@ember/template";
+import borderColor from "discourse/helpers/border-color";
+import dIcon from "discourse-common/helpers/d-icon";
+
+export default class CategoryGroupExtraLink extends Component {
+  get borderColor() {
+    // Using JSON schema we get the hash, and then borderColor adds another one. Slice it out!
+    return this.args.link.color.slice(1);
+  }
+  <template>
+    <li style={{borderColor this.borderColor}} class="extra-link category-box">
+      <div class="category-box-inner">
+        <div class="category-details">
+          <div class="category-box-heading">
+            <a class="parent-box-link" href={{@link.url}}>
+              {{dIcon @link.icon}}
+              <h3 class="title">
+                {{@link.title}}
+              </h3>
+            </a>
+          </div>
+
+          <div class="description">
+            {{htmlSafe @link.description}}
+          </div>
+        </div>
+      </div>
+    </li>
+  </template>
+}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,7 +2,8 @@ en:
   theme_metadata:
     description: "custom category page with group settings"
     settings:
-      category_groups: "Format as: Group name: category-slug, category-slug-2"
+      category_groups: "Format as: Group name: category-slug, extra-link-id, category-slug-2"
+      extra_links: "Extra links that can be mixed into category list. Add link ID in category_groups setting to render"
       show_on_mobile: "Show the collapsible category box groups on mobile"
       show_ungrouped: "Display a group of categories that aren't assigned to another group"
       hide_muted_subcategories: "When enabled, a non-muted parent category will not appear under the muted section if it has a muted subcategory"

--- a/settings.yml
+++ b/settings.yml
@@ -39,8 +39,8 @@ extra_links:
           "icon": {
             "type": "string",
             "title": "Icon",
-            "description": "An icon for the link",
-            "default": "fas fa-link"
+            "description": "An icon for the link. Example: heart",
+            "default": ""
           }
         },
         "required": ["id", "url", "title", "color"]

--- a/settings.yml
+++ b/settings.yml
@@ -1,6 +1,51 @@
 category_groups:
   type: "list"
   default: "Default Categories: staff, site-feedback, lounge"
+extra_links:
+  default: >
+    []
+  json_schema: >-
+    {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "ID",
+            "description": "A unique identifier for the link"
+          },
+          "url": {
+            "type": "string",
+            "title": "URL",
+            "description": "The URL for the link"
+          },
+          "color": {
+            "type": "string",
+            "title": "Color",
+            "description": "The color associated with the link",
+            "format": "color"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title",
+            "description": "The title of the link"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "A short description of the link"
+          },
+          "icon": {
+            "type": "string",
+            "title": "Icon",
+            "description": "An icon for the link",
+            "default": "fas fa-link"
+          }
+        },
+        "required": ["id", "url", "title", "color"]
+      }
+    }
 
 show_on_mobile:
   default: true

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe "Testing Category Groups Theme Component", system: true do
+  let!(:theme_component) { upload_theme_component }
+  let!(:category) { Fabricate(:category) }
+
+  class ExampleGroupLink
+    def self.id
+      "some_id"
+    end
+    def self.title
+      "Example"
+    end
+    def self.description
+      "This is an example group"
+    end
+  end
+
+  before do
+    sign_in(Fabricate(:admin))
+    theme_component.update_setting(
+      :extra_links,
+      [
+        {
+          "id" => ExampleGroupLink.id,
+          "url" => "/c/#{category.slug}",
+          "color" => "#ff0000",
+          "title" => ExampleGroupLink.title,
+          "description" => ExampleGroupLink.description,
+          "icon" => "heart",
+        },
+      ].to_json,
+    )
+    theme_component.update_setting(:fancy_styling, true)
+    theme_component.update_setting(
+      :category_groups,
+      "Default Categories: #{ExampleGroupLink.id}, #{category.slug}",
+    )
+    SiteSetting.desktop_category_page_style = "categories_boxes"
+    theme_component.save!
+  end
+
+  it "should display the extra links" do
+    visit "/categories"
+
+    expect(page).to have_text ExampleGroupLink.title
+    expect(page).to have_text ExampleGroupLink.description
+    find(".extra-link-#{ExampleGroupLink.id}").click
+    expect(page).to have_text "#{category.name} topics"
+  end
+end


### PR DESCRIPTION
This PR adds an `extra_links` JSON schema setting to defined extra links. The links can then be added to the category list by ID like:

![Screenshot 2024-06-06 at 10 27 11 AM](https://github.com/discourse/discourse-category-groups-component/assets/16214023/25b8ecbe-df39-43eb-8874-895f74d5886c)

This PR also changes how category rows are rendered. Currently the order is not retained when rendering the list. This is because we were looping through all categories from the server and checking if the category was in the TC settings. This PR reverses the logic so we loop through each category slug and find the corresponding category to retain the order defined in the theme settings.

Editor for links:

![Screenshot 2024-06-06 at 10 28 52 AM](https://github.com/discourse/discourse-category-groups-component/assets/16214023/3e5b23e4-9c27-4849-8270-c6692be2b7a5)


And what it looks like with two custom links:
![Screenshot 2024-06-06 at 10 29 14 AM](https://github.com/discourse/discourse-category-groups-component/assets/16214023/a62a7043-78aa-4ec3-8eae-1a4029653e9b)


