### PR TITLE
Add markdown support for description

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -30,6 +30,7 @@
     .description {
       text-align: left;
       font-weight: normal;
+      pointer-events: auto;
     }
 
     .subcategories {

--- a/javascripts/discourse/components/category-group-extra-link.gjs
+++ b/javascripts/discourse/components/category-group-extra-link.gjs
@@ -1,15 +1,25 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { htmlSafe } from "@ember/template";
 import borderColor from "discourse/helpers/border-color";
 import { cook } from "discourse/lib/text";
 import dIcon from "discourse-common/helpers/d-icon";
-
-export async function getCookedDescription(desc) {
-  const cooked = await cook(desc);
-  return htmlSafe(cooked);
-}
+import I18n from "discourse-i18n";
 
 export default class CategoryGroupExtraLink extends Component {
+  @tracked cookedDescription = I18n.t("loading");
+
+  constructor() {
+    super(...arguments);
+    this.cookDescription(this.args.link.description);
+  }
+
+  cookDescription(description) {
+    return cook(description)
+      .then(htmlSafe)
+      .then((cooked) => (this.cookedDescription = cooked));
+  }
+
   get borderColor() {
     // Using JSON schema we get the hash, and then borderColor adds another one. Slice it out!
     return this.args.link.color.slice(1);
@@ -31,7 +41,7 @@ export default class CategoryGroupExtraLink extends Component {
           </div>
 
           <div class="description">
-            {{getCookedDescription @link.description}}
+            {{this.cookedDescription}}
           </div>
         </div>
       </div>

--- a/javascripts/discourse/components/category-group-extra-link.gjs
+++ b/javascripts/discourse/components/category-group-extra-link.gjs
@@ -1,25 +1,9 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
-import { htmlSafe } from "@ember/template";
+import CookText from "discourse/components/cook-text";
 import borderColor from "discourse/helpers/border-color";
-import { cook } from "discourse/lib/text";
 import dIcon from "discourse-common/helpers/d-icon";
-import I18n from "discourse-i18n";
 
 export default class CategoryGroupExtraLink extends Component {
-  @tracked cookedDescription = I18n.t("loading");
-
-  constructor() {
-    super(...arguments);
-    this.cookDescription(this.args.link.description);
-  }
-
-  cookDescription(description) {
-    return cook(description)
-      .then(htmlSafe)
-      .then((cooked) => (this.cookedDescription = cooked));
-  }
-
   get borderColor() {
     // Using JSON schema we get the hash, and then borderColor adds another one. Slice it out!
     return this.args.link.color.slice(1);
@@ -41,7 +25,7 @@ export default class CategoryGroupExtraLink extends Component {
           </div>
 
           <div class="description">
-            {{this.cookedDescription}}
+            <CookText @rawText={{@link.description}} />
           </div>
         </div>
       </div>

--- a/javascripts/discourse/components/category-group-extra-link.gjs
+++ b/javascripts/discourse/components/category-group-extra-link.gjs
@@ -2,6 +2,12 @@ import Component from "@glimmer/component";
 import { htmlSafe } from "@ember/template";
 import borderColor from "discourse/helpers/border-color";
 import dIcon from "discourse-common/helpers/d-icon";
+import { cook } from "discourse/lib/text";
+
+export async function getCookedDescription(desc) {
+  const cooked = await cook(desc);
+  return htmlSafe(cooked);
+}
 
 export default class CategoryGroupExtraLink extends Component {
   get borderColor() {
@@ -25,7 +31,7 @@ export default class CategoryGroupExtraLink extends Component {
           </div>
 
           <div class="description">
-            {{htmlSafe @link.description}}
+            {{getCookedDescription @link.description}}
           </div>
         </div>
       </div>

--- a/javascripts/discourse/components/category-group-extra-link.gjs
+++ b/javascripts/discourse/components/category-group-extra-link.gjs
@@ -1,8 +1,8 @@
 import Component from "@glimmer/component";
 import { htmlSafe } from "@ember/template";
 import borderColor from "discourse/helpers/border-color";
-import dIcon from "discourse-common/helpers/d-icon";
 import { cook } from "discourse/lib/text";
+import dIcon from "discourse-common/helpers/d-icon";
 
 export async function getCookedDescription(desc) {
   const cooked = await cook(desc);

--- a/settings.yml
+++ b/settings.yml
@@ -33,6 +33,7 @@ extra_links:
           },
           "description": {
             "type": "string",
+            "format": "markdown",
             "title": "Description",
             "description": "A short description of the link"
           },

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -41,26 +41,21 @@ RSpec.describe "Testing Category Groups Theme Component", system: true do
   it "should display the extra links" do
     visit "/categories"
 
-    expect(page).to have_text ExampleGroupLink.title
-    expect(page).to have_text ExampleGroupLink.description
-    find(".extra-link-#{ExampleGroupLink.id}").click
+    extra_link = find(".extra-link-#{ExampleGroupLink.id}")
+    expect(extra_link).to have_text ExampleGroupLink.title
+    expect(extra_link[:innerHTML]).to include PrettyText.cook(ExampleGroupLink.description)
+    extra_link.find("a").click
     expect(page).to have_text "#{category.name} topics"
   end
 
   it "should render markdown as html" do
-    expect(ExampleGroupLink.description).to have_tag(
-      "em",
-      text: "The link description",
-      count: 1,
-    )
+    visit "/categories"
 
-    expect(ExampleGroupLink.description).to have_tag(
-      "strong",
-      text: "Markdown",
-      count: 1,
-    )
+    expect(page).to have_tag("em", text: "The link description", count: 1)
 
-    expect(ExampleGroupLink.description).to have_tag(
+    expect(page).to have_tag("strong", text: "Markdown", count: 1)
+
+    expect(page).to have_tag(
       "img",
       with: {
         title: ":slightly_smiling_face:",

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Testing Category Groups Theme Component", system: true do
       "Example"
     end
     def self.description
-      "This is an example group"
+      "This is an example group. *The link description* supports **Markdown** formatting. :slightly_smiling_face:"
     end
   end
 
@@ -45,5 +45,29 @@ RSpec.describe "Testing Category Groups Theme Component", system: true do
     expect(page).to have_text ExampleGroupLink.description
     find(".extra-link-#{ExampleGroupLink.id}").click
     expect(page).to have_text "#{category.name} topics"
+  end
+
+  it "should render markdown as html" do
+    expect(ExampleGroupLink.description).to have_tag(
+      "em",
+      text: "The link description",
+      count: 1,
+    )
+
+    expect(ExampleGroupLink.description).to have_tag(
+      "strong",
+      text: "Markdown",
+      count: 1,
+    )
+
+    expect(ExampleGroupLink.description).to have_tag(
+      "img",
+      with: {
+        title: ":slightly_smiling_face:",
+        alt: ":slightly_smiling_face:",
+        class: "emoji",
+      },
+      count: 1,
+    )
   end
 end


### PR DESCRIPTION
I'm trying to get the description field to support Markdown, so that the box used for the extra links can use custom links similar to how subgroups are rendered, or could have thumbnail images rendered in their places too.

However, I am having a Promise related issue with the `cook` method.

@Grubba27 could you advice on this?