### PR TITLE
feat(settings): replace json_schema settings with object type

### DIFF
--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -54,7 +54,7 @@ export default class CategoriesGroups extends Component {
     const categoryGroupList = parsedSettings.reduce((groups, obj) => {
       const categoryArray = obj.categories.split(",").map((str) => str.trim());
       const categoryGroup = [];
-      const securityGroups = obj.security ?? [0];
+      const categoryGroupVisibility = obj.visibility ?? [0];
 
       // Iterate through each category/link in the order specified in settings
       categoryArray.forEach((categoryOrLinkId) => {
@@ -74,7 +74,7 @@ export default class CategoriesGroups extends Component {
         }
       });
 
-      const displayGroup = securityGroups.some((group) =>
+      const displayGroup = categoryGroupVisibility.some((group) =>
         currentUserGroups.includes(group)
       );
 

--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -74,16 +74,15 @@ export default class CategoriesGroups extends Component {
         }
       });
 
-      if (categoryGroup.length > 0) {
+      const displayGroup = securityGroups.some((group) =>
+        currentUserGroups.includes(group)
+      );
+
+      if (displayGroup && categoryGroup.length > 0) {
         groups.push({ name: obj.categoryGroup, items: categoryGroup });
       }
 
-      if (securityGroups.some((group) =>
-        currentUserGroups.includes(group)
-      )) {
-        return groups;
-      }
-      return [];
+      return groups;
     }, []);
 
     // Find ungrouped categories

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,8 +12,8 @@ en:
             categories:
               label: "Slugs"
               description: "The category slugs and/or extra-link IDs, separated by commas."
-            security:
-              label: "Security"
+            visibility:
+              label: "Visibility"
               description: "The user groups that can see this category group. Leave empty, or select 'everyone' to show to all users."
       links:
         description: "Extra links that can be mixed into category list. Add link ID in Grouped categories setting to render"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,8 +2,41 @@ en:
   theme_metadata:
     description: "custom category page with group settings"
     settings:
-      category_groups: "Format as: Group name: category-slug, extra-link-id, category-slug-2"
-      extra_links: "Extra links that can be mixed into category list. Add link ID in category_groups setting to render"
+      grouped_categories:
+        description: "Group categories together"
+        schema:
+          properties:
+            categoryGroup:
+              label: "Group heading"
+              description: "The name of the group"
+            categories:
+              label: "Slugs"
+              description: "The category slugs and/or extra-link IDs, separated by commas."
+            security:
+              label: "Security"
+              description: "The user groups that can see this category group. Leave empty, or select 'everyone' to show to all users."
+      links:
+        description: "Extra links that can be mixed into category list. Add link ID in Grouped categories setting to render"
+        schema:
+          properties:
+            id:
+              label: "ID"
+              description: "The ID of the link"
+            url:
+              label: "URL"
+              description: "The URL of the link"
+            color:
+              label: "Color"
+              description: "CSS compatible hexadecimal color code for the link. ie. #F1592A"
+            title:
+              label: "Title"
+              description: "The title of the link"
+            description:
+              label: "Description"
+              description: "The description of the link"
+            icon:
+              label: "Icon"
+              description: "The icon of the link"
       show_on_mobile: "Show the collapsible category box groups on mobile"
       show_ungrouped: "Display a group of categories that aren't assigned to another group"
       hide_muted_subcategories: "When enabled, a non-muted parent category will not appear under the muted section if it has a muted subcategory"

--- a/migrations/settings/0001-use-objects.js
+++ b/migrations/settings/0001-use-objects.js
@@ -3,7 +3,7 @@ export default function migrate(settings) {
         const groups = settings.get("category_groups");
         const categoryGroups = groups.split("|").map((i) => {
             const [categoryGroup, categories] = i.split(":").map((str) => str.trim());
-            return { categoryGroup, categories, security: [0] };
+            return { categoryGroup, categories, visibility: [0] };
         });
 
         settings.set("grouped_categories", categoryGroups);

--- a/migrations/settings/0001-use-objects.js
+++ b/migrations/settings/0001-use-objects.js
@@ -1,0 +1,20 @@
+export default function migrate(settings) {
+    if (settings.has("category_groups")) {
+        const groups = settings.get("category_groups");
+        const categoryGroups = groups.split("|").map((i) => {
+            const [categoryGroup, categories] = i.split(":").map((str) => str.trim());
+            return { categoryGroup, categories, security: [0] };
+        });
+
+        settings.set("grouped_categories", categoryGroups);
+        settings.delete("category_groups");
+    }
+
+    if (settings.has("extra_links")) {
+        const links = settings.get("extra_links");
+        settings.set("links", JSON.parse(links || "[]"));
+        settings.delete("extra_links");
+    }
+
+    return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -1,52 +1,61 @@
-category_groups:
-  type: "list"
-  default: "Default Categories: staff, site-feedback, lounge"
-extra_links:
-  default: >
-    []
-  json_schema: >-
+grouped_categories:
+  type: objects
+  default: [
     {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "ID",
-            "description": "A unique identifier for the link"
-          },
-          "url": {
-            "type": "string",
-            "title": "URL",
-            "description": "The URL for the link"
-          },
-          "color": {
-            "type": "string",
-            "title": "Color",
-            "description": "The color associated with the link",
-            "format": "color"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title",
-            "description": "The title of the link"
-          },
-          "description": {
-            "type": "string",
-            "format": "markdown",
-            "title": "Description",
-            "description": "A short description of the link"
-          },
-          "icon": {
-            "type": "string",
-            "title": "Icon",
-            "description": "An icon for the link. Example: heart",
-            "default": ""
-          }
-        },
-        "required": ["id", "url", "title", "color"]
-      }
+      "categoryGroup": "Default Categories",
+      "categories": "staff, site-feedback, lounge",
+      "security": [
+        0
+      ]
     }
+  ]
+  schema:
+    name: "Category Groups"
+    identifier: categoryGroup
+    properties:
+      categoryGroup:
+        type: string
+        required: true
+      categories:
+        type: string
+        required: true
+      security:
+        type: groups
+        min: 1
+
+links:
+  type: objects
+  default: [
+    {
+      "id": "example",
+      "url": "https://example.com",
+      "color": "#F1592A",
+      "title": "Example Link",
+      "description": "This is an example link",
+      "icon": ""
+    }
+  ]
+  schema:
+    name: "Links"
+    identifier: id
+    properties:
+      id:
+        type: string
+        required: true
+      url:
+        type: string
+        required: true
+        url: true
+      color:
+        type: string
+        required: true
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+      icon:
+        type: string
 
 show_on_mobile:
   default: true

--- a/settings.yml
+++ b/settings.yml
@@ -1,4 +1,5 @@
 grouped_categories:
+  refresh: true
   type: objects
   default: [
     {
@@ -24,6 +25,7 @@ grouped_categories:
         min: 1
 
 links:
+  refresh: true
   type: objects
   default: [
     {

--- a/settings.yml
+++ b/settings.yml
@@ -5,7 +5,7 @@ grouped_categories:
     {
       "categoryGroup": "Default Categories",
       "categories": "staff, site-feedback, lounge",
-      "security": [
+      "visibility": [
         0
       ]
     }
@@ -20,7 +20,7 @@ grouped_categories:
       categories:
         type: string
         required: true
-      security:
+      visibility:
         type: groups
         min: 1
 

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Testing Category Groups Theme Component", system: true do
   before do
     sign_in(Fabricate(:admin))
     theme_component.update_setting(
-      :extra_links,
+      :links,
       [
         {
           "id" => ExampleGroupLink.id,
@@ -32,8 +32,14 @@ RSpec.describe "Testing Category Groups Theme Component", system: true do
     )
     theme_component.update_setting(:fancy_styling, true)
     theme_component.update_setting(
-      :category_groups,
-      "Default Categories: #{ExampleGroupLink.id}, #{category.slug}",
+      :grouped_categories,
+      [
+        {
+          "categoryGroup" => "Default Categories",
+          "categories" => "#{ExampleGroupLink.id}, #{category.slug}",
+          "visibility" => [0],
+        }
+      ].to_json,
     )
     SiteSetting.desktop_category_page_style = "categories_boxes"
     theme_component.save!

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Testing Category Groups Theme Component", system: true do
           "categoryGroup" => "Default Categories",
           "categories" => "#{ExampleGroupLink.id}, #{category.slug}",
           "visibility" => [0],
-        }
+        },
       ].to_json,
     )
     SiteSetting.desktop_category_page_style = "categories_boxes"


### PR DESCRIPTION
* Replaces json_schema settings with object type
* Adds a visibility option based on user groups.

The added **visibility** setting allows creating a customized user experience.

Define a category group, add the categories and extra-links as you normally would. Then select one or multiple user groups only their members should see the category group. 

<img width="824" alt="Screenshot 2025-04-12 at 10 54 41 PM" src="https://github.com/user-attachments/assets/124573e2-6a23-445a-be29-5c5afdce1099" />


<img width="824" alt="Screenshot 2025-04-12 at 2 31 37 AM" src="https://github.com/user-attachments/assets/5a3291c6-8e42-4fd4-8a9c-bed97961f332" />
