### PR TITLE
FEATURE: use category badges from core

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -33,10 +33,18 @@
       pointer-events: auto;
     }
 
+    .description p {
+      margin: 0;
+    }
+
     .subcategories {
       gap: 0 0.5em;
       margin-top: auto;
     }
+  }
+
+  .badge-category__wrapper {
+    font-size: unset;
   }
 
   .category-box-heading {
@@ -176,11 +184,11 @@
       .category-box-inner {
         border: none;
         padding: 2em;
+        transition: background 0.25s ease-in-out;
 
         @media screen and (max-width: 700px) {
           padding: 2em 1em 1.25em;
         }
-        transition: background 0.25s ease-in-out;
       }
 
       .category-box-heading {

--- a/javascripts/discourse/components/categories-groups.hbs
+++ b/javascripts/discourse/components/categories-groups.hbs
@@ -48,13 +48,7 @@
                     <div class="category-details">
                       <div class="category-box-heading">
                         <a class="parent-box-link" href={{c.url}}>
-                          <h3>
-                            {{category-title-before category=c}}
-                            {{#if c.read_restricted}}
-                              {{d-icon "lock"}}
-                            {{/if}}
-                            {{c.name}}
-                          </h3>
+                          <h3>{{this.categoryName c}}</h3>
                         </a>
                       </div>
 

--- a/javascripts/discourse/components/categories-groups.js
+++ b/javascripts/discourse/components/categories-groups.js
@@ -3,6 +3,8 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { slugify } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
+import { categoryBadgeHTML } from "discourse/helpers/category-link";
+import { htmlSafe } from "@ember/template";
 
 function parseSettings(settings) {
   return settings.split("|").map((i) => {
@@ -34,6 +36,15 @@ export default class CategoriesGroups extends Component {
     return (
       currentRoute === "discovery.categories" &&
       categoryPageStyle.includes("boxes")
+    );
+  }
+
+  categoryName(category) {
+    return htmlSafe(
+      categoryBadgeHTML(category, {
+        allowUncategorized: true,
+        link: false,
+      })
     );
   }
 

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -66,4 +66,18 @@ RSpec.describe "Testing Category Groups Theme Component", system: true do
       count: 1,
     )
   end
+
+  it "should render category badges" do
+    visit "/categories"
+
+    expect(page).to have_css(".category-box-heading .d-icon-heart", count: 1)
+    expect(page).to have_css(".category-box-heading .--style-square", count: 2)
+  end
+
+  it "works with core category icons and emojis" do
+    category.update!(style_type: "emoji", emoji: "wave")
+    visit "/categories"
+
+    expect(page).to have_css(".category-box-heading .emoji[alt='wave']", count: 1)
+  end
 end


### PR DESCRIPTION
Updates category titles to use icon and emoji styles from core rather than the soon to be deprecated [Category Icons](https://meta.discourse.org/t/category-icons/104683) component.

We still support the icons added in this theme component as extra links.

### How it looks (Desktop)

With the "fancy styling" option selected:

<img width="600" alt="Screenshot 2025-04-29 at 11 38 25 AM" src="https://github.com/user-attachments/assets/b5a23837-6373-47de-8096-0276d5ceb32e" />

With the default styling:

<img width="600" alt="Screenshot 2025-04-29 at 11 34 18 AM" src="https://github.com/user-attachments/assets/396b7a8b-909b-40de-84ce-7338e4798a67" />

Extra link added through the component with icon (see "Marketing" example):

<img width="1118" alt="Screenshot 2025-04-29 at 11 33 00 AM" src="https://github.com/user-attachments/assets/2a7f17bf-4143-472d-a879-b5d0a4aa9649" />

### How it looks (Mobile)

With the "fancy styling" option selected:

<img width="426" alt="Screenshot 2025-04-29 at 11 37 57 AM" src="https://github.com/user-attachments/assets/6873a61b-d514-4e27-bac6-c8ca46a56a29" />

With the default styling:

<img width="429" alt="Screenshot 2025-04-29 at 11 35 12 AM" src="https://github.com/user-attachments/assets/477a46cb-48f3-4ba5-a63a-b111e6447ea1" />
