### PR TITLE
FEATURE: migrate settings to object settings, localizable group names

### DIFF
--- a/javascripts/discourse/components/categories-groups.gjs
+++ b/javascripts/discourse/components/categories-groups.gjs
@@ -18,15 +18,8 @@ import categoryLink, {
 import icon from "discourse/helpers/d-icon";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { slugify } from "discourse/lib/utilities";
-import { i18n } from "discourse-i18n";
+import I18nInstance, { i18n } from "discourse-i18n";
 import CategoryGroupExtraLink from "./category-group-extra-link";
-
-function parseSettings(settings) {
-  return settings.split("|").map((i) => {
-    const [categoryGroup, categories] = i.split(":").map((str) => str.trim());
-    return { categoryGroup, categories };
-  });
-}
 
 const ExtraLink = class {
   constructor(args) {
@@ -43,6 +36,14 @@ const ExtraLink = class {
 export default class CategoriesGroups extends Component {
   @service router;
   @service siteSettings;
+
+  localizedGroupName(group) {
+    const locale = I18nInstance.currentLocale();
+    const translation = (group.translations || []).find(
+      (t) => t.locale === locale
+    );
+    return translation?.name || group.name;
+  }
 
   get shouldShow() {
     const currentRoute = this.router.currentRouteName;
@@ -64,41 +65,48 @@ export default class CategoriesGroups extends Component {
   }
 
   get categoryGroupList() {
-    const parsedSettings = parseSettings(settings.category_groups);
-    const extraLinks = JSON.parse(settings.extra_links || "[]");
+    const parsedSettings = settings.category_groups;
+    const extraLinks = settings.extra_links || [];
 
-    // Initialize an array to keep track of found categories and used links
+    // Keep track of which categories landed in a group so the rest fall through
+    // to the "ungrouped" section.
     const foundCategories = [];
-    const usedLinks = [];
 
-    // Helper function to find extra link by ID
-    const findExtraLinkById = (id) => extraLinks.find((link) => link.id === id);
+    // Returns a category followed by any extra links positioned after it (via
+    // the link's `show_after` category), so links render inline next to a
+    // category.
+    const withLinks = (categories) => {
+      const items = [];
+      categories.forEach((category) => {
+        items.push(category);
+        extraLinks
+          .filter((link) => (link.show_after || []).includes(category.id))
+          .forEach((link) => items.push(new ExtraLink(link)));
+      });
+      return items;
+    };
 
     // Iterate through parsed settings in the defined order
     const categoryGroupList = parsedSettings.reduce((groups, obj) => {
-      const categoryArray = obj.categories.split(",").map((str) => str.trim());
-      const categoryGroup = [];
+      const groupCategories = (obj.categories || [])
+        .map((id) =>
+          this.categories.find((cat) => cat.id === Number(id) && !cat.hasMuted)
+        )
+        .filter(Boolean);
 
-      // Iterate through each category/link in the order specified in settings
-      categoryArray.forEach((categoryOrLinkId) => {
-        const category = this.categories.find(
-          (cat) => cat.slug === categoryOrLinkId && !cat.hasMuted
-        );
+      groupCategories.forEach((c) => foundCategories.push(c.slug));
 
-        if (category) {
-          categoryGroup.push(category);
-          foundCategories.push(category.slug);
-        } else {
-          const extraLink = findExtraLinkById(categoryOrLinkId);
-          if (extraLink) {
-            categoryGroup.push(new ExtraLink(extraLink));
-            usedLinks.push(extraLink.id);
-          }
-        }
-      });
+      const items = withLinks(groupCategories);
 
-      if (categoryGroup.length > 0) {
-        groups.push({ name: obj.categoryGroup, items: categoryGroup });
+      if (items.length > 0) {
+        // `slug` is derived from the default name so it stays stable across
+        // locales (used for CSS classes and localStorage collapse state),
+        // while `name` is the localized label shown to the user.
+        groups.push({
+          name: this.localizedGroupName(obj),
+          slug: slugify(obj.name),
+          items,
+        });
       }
       return groups;
     }, []);
@@ -116,25 +124,29 @@ export default class CategoriesGroups extends Component {
     if (settings.show_ungrouped && ungroupedCategories.length > 0) {
       categoryGroupList.push({
         name: i18n(themePrefix("ungrouped_categories_title")),
-        items: ungroupedCategories,
+        slug: "ungrouped",
+        items: withLinks(ungroupedCategories),
       });
     }
 
     if (mutedCategories.length > 0) {
-      categoryGroupList.push({ name: "muted", items: mutedCategories });
+      categoryGroupList.push({
+        name: i18n(themePrefix("muted_categories_title")),
+        slug: "muted",
+        items: mutedCategories,
+      });
     }
 
     return categoryGroupList;
   }
 
   @action
-  toggleCategories(name, event) {
+  toggleCategories(slug, event) {
     event.preventDefault();
 
-    const id = slugify(name);
     const storedCategories =
       JSON.parse(localStorage.getItem("categoryGroups")) || [];
-    const categoryClass = `.custom-category-group-${id}`;
+    const categoryClass = `.custom-category-group-${slug}`;
 
     if (storedCategories.includes(categoryClass)) {
       storedCategories.removeObject(categoryClass);
@@ -162,11 +174,6 @@ export default class CategoriesGroups extends Component {
     });
   }
 
-  @action
-  slugifyIdentifier(str) {
-    return slugify(str);
-  }
-
   <template>
     {{#if this.shouldShow}}
       <section class="category-boxes with-logos with-subcategories">
@@ -175,14 +182,11 @@ export default class CategoriesGroups extends Component {
           {{didInsert this.initializeLocalStorage}}
         >
           {{#each this.categoryGroupList as |t|}}
-            <div
-              class="custom-category-group-{{this.slugifyIdentifier t.name}}
-                is-expanded"
-            >
+            <div class="custom-category-group-{{t.slug}} is-expanded">
               <a
-                {{on "click" (fn this.toggleCategories t.name)}}
+                {{on "click" (fn this.toggleCategories t.slug)}}
                 href
-                id={{this.slugifyIdentifier t.name}}
+                id={{t.slug}}
                 class="custom-category-group-toggle"
               >
                 <h2>{{t.name}}</h2>

--- a/javascripts/discourse/components/categories-groups.gjs
+++ b/javascripts/discourse/components/categories-groups.gjs
@@ -72,16 +72,16 @@ export default class CategoriesGroups extends Component {
     // to the "ungrouped" section.
     const foundCategories = [];
 
-    // Returns a category followed by any extra links positioned after it (via
-    // the link's `show_after` category), so links render inline next to a
+    // Returns each category preceded by any extra links positioned before it
+    // (via the link's `show_before` category), so links render inline next to a
     // category.
     const withLinks = (categories) => {
       const items = [];
       categories.forEach((category) => {
-        items.push(category);
         extraLinks
-          .filter((link) => (link.show_after || []).includes(category.id))
+          .filter((link) => (link.show_before || []).includes(category.id))
           .forEach((link) => items.push(new ExtraLink(link)));
+        items.push(category);
       });
       return items;
     };

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -11,8 +11,8 @@ en:
               description: "Any unique identifier for this link (e.g. my-link)."
             color:
               description: "Use hex format, e.g. #00ff00"
-            show_after:
-              description: "The extra link will appear after this category."
+            show_before:
+              description: "The extra link will appear before this category."
       show_on_mobile: "Show the collapsible category box groups on mobile"
       show_ungrouped: "Display a group of categories that aren't assigned to another group"
       hide_muted_subcategories: "When enabled, a non-muted parent category will not appear under the muted section if it has a muted subcategory"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,10 +2,20 @@ en:
   theme_metadata:
     description: "custom category page with group settings"
     settings:
-      category_groups: "Format as: Group name: category-slug, extra-link-id, category-slug-2"
-      extra_links: "Extra links that can be mixed into category list. Add link ID in category_groups setting to render"
+      category_groups: "Define each group with a name and the categories it contains (in display order). Use the translations field to localize a group's name per locale (e.g. locale 'fr')."
+      extra_links:
+        description: "Extra links that can be mixed into the category list. Set a link's \"show after\" category to position it after that category."
+        schema:
+          properties:
+            id:
+              description: "Any unique identifier for this link (e.g. my-link)."
+            color:
+              description: "Use hex format, e.g. #00ff00"
+            show_after:
+              description: "The extra link will appear after this category."
       show_on_mobile: "Show the collapsible category box groups on mobile"
       show_ungrouped: "Display a group of categories that aren't assigned to another group"
       hide_muted_subcategories: "When enabled, a non-muted parent category will not appear under the muted section if it has a muted subcategory"
       fancy_styling: "Turn on additional styling"
   ungrouped_categories_title: "Other"
+  muted_categories_title: "Muted"

--- a/migrations/settings/0001-convert-category-groups-to-objects.js
+++ b/migrations/settings/0001-convert-category-groups-to-objects.js
@@ -1,0 +1,60 @@
+export default function migrate(settings, helpers) {
+  const rawGroups = settings.get("category_groups");
+  const rawLinks = settings.get("extra_links");
+
+  // The original settings stored strings (list / json_schema). Once converted
+  // they're arrays, so a non-string value means that setting is already migrated.
+  const groupsNeedMigration = typeof rawGroups === "string";
+  const linksNeedMigration = typeof rawLinks === "string";
+
+  if (!groupsNeedMigration && !linksNeedMigration) {
+    return settings;
+  }
+
+  const links = linksNeedMigration ? JSON.parse(rawLinks || "[]") : [];
+  const linksById = new Map(links.map((link) => [link.id, link]));
+
+  if (groupsNeedMigration) {
+    const groups = rawGroups
+      .split("|")
+      .map((chunk) => {
+        const [name, items] = chunk.split(":").map((str) => str.trim());
+
+        if (!name) {
+          return null;
+        }
+
+        const tokens = (items || "")
+          .split(",")
+          .map((str) => str.trim())
+          .filter(Boolean);
+
+        const categories = [];
+        let lastCategoryId = null;
+
+        tokens.forEach((token) => {
+          const categoryId = helpers?.getCategoryIdBySlug?.(token);
+
+          if (categoryId) {
+            categories.push(categoryId);
+            lastCategoryId = categoryId;
+          } else if (linksById.has(token) && lastCategoryId) {
+            // The token is an extra-link ID interleaved after a category;
+            // preserve its position via the link's `show_after`.
+            linksById.get(token).show_after = [lastCategoryId];
+          }
+        });
+
+        return { name, categories };
+      })
+      .filter(Boolean);
+
+    settings.set("category_groups", groups);
+  }
+
+  if (linksNeedMigration) {
+    settings.set("extra_links", links);
+  }
+
+  return settings;
+}

--- a/migrations/settings/0001-convert-category-groups-to-objects.js
+++ b/migrations/settings/0001-convert-category-groups-to-objects.js
@@ -30,18 +30,19 @@ export default function migrate(settings, helpers) {
           .filter(Boolean);
 
         const categories = [];
-        let lastCategoryId = null;
+        let pendingLinks = [];
 
         tokens.forEach((token) => {
           const categoryId = helpers?.getCategoryIdBySlug?.(token);
 
           if (categoryId) {
             categories.push(categoryId);
-            lastCategoryId = categoryId;
-          } else if (linksById.has(token) && lastCategoryId) {
-            // The token is an extra-link ID interleaved after a category;
-            // preserve its position via the link's `show_after`.
-            linksById.get(token).show_after = [lastCategoryId];
+            // Any links seen since the previous category were interleaved
+            // before this one; preserve that position via `show_before`.
+            pendingLinks.forEach((link) => (link.show_before = [categoryId]));
+            pendingLinks = [];
+          } else if (linksById.has(token)) {
+            pendingLinks.push(linksById.get(token));
           }
         });
 

--- a/settings.yml
+++ b/settings.yml
@@ -95,7 +95,7 @@ extra_links:
         type: string
       icon:
         type: string
-      show_after:
+      show_before:
         type: categories
         validations:
           max: 1

--- a/settings.yml
+++ b/settings.yml
@@ -1,52 +1,104 @@
 category_groups:
-  type: "list"
-  default: "Default Categories: staff, site-feedback, lounge"
+  type: objects
+  default: []
+  schema:
+    name: category group
+    identifier: name
+    properties:
+      name:
+        type: string
+        required: true
+      categories:
+        type: categories
+      translations:
+        type: objects
+        schema:
+          name: translation
+          identifier: locale
+          properties:
+            locale:
+              type: enum
+              required: true
+              choices:
+                - ar
+                - be
+                - bg
+                - bs_BA
+                - ca
+                - cs
+                - da
+                - de
+                - el
+                - en
+                - en_GB
+                - es
+                - et
+                - fa_IR
+                - fi
+                - fr
+                - gl
+                - he
+                - hr
+                - hu
+                - hy
+                - id
+                - it
+                - ja
+                - ko
+                - lt
+                - lv
+                - nb_NO
+                - nl
+                - pl_PL
+                - pt
+                - pt_BR
+                - ro
+                - ru
+                - sk
+                - sl
+                - sq
+                - sr
+                - sv
+                - sw
+                - te
+                - th
+                - tr_TR
+                - ug
+                - uk
+                - ur
+                - vi
+                - zh_CN
+                - zh_TW
+            name:
+              type: string
+              required: true
 extra_links:
-  default: >
-    []
-  json_schema: >-
-    {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "ID",
-            "description": "A unique identifier for the link"
-          },
-          "url": {
-            "type": "string",
-            "title": "URL",
-            "description": "The URL for the link"
-          },
-          "color": {
-            "type": "string",
-            "title": "Color",
-            "description": "The color associated with the link",
-            "format": "color"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title",
-            "description": "The title of the link"
-          },
-          "description": {
-            "type": "string",
-            "format": "markdown",
-            "title": "Description",
-            "description": "A short description of the link"
-          },
-          "icon": {
-            "type": "string",
-            "title": "Icon",
-            "description": "An icon for the link. Example: heart",
-            "default": ""
-          }
-        },
-        "required": ["id", "url", "title", "color"]
-      }
-    }
+  type: objects
+  default: []
+  schema:
+    name: extra link
+    identifier: title
+    properties:
+      id:
+        type: string
+        required: true
+      url:
+        type: string
+        required: true
+      title:
+        type: string
+        required: true
+      color:
+        type: string
+        required: true
+      description:
+        type: string
+      icon:
+        type: string
+      show_after:
+        type: categories
+        validations:
+          max: 1
 
 show_on_mobile:
   default: true

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -85,7 +85,10 @@ RSpec.describe "Category Groups", system: true do
   it "displays the group name in the default locale" do
     visit "/categories"
 
-    expect(page).to have_css(".custom-category-group-default-categories h2", text: "Default Categories")
+    expect(page).to have_css(
+      ".custom-category-group-default-categories h2",
+      text: "Default Categories",
+    )
   end
 
   it "localizes the group name for the user's locale" do

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -70,8 +70,10 @@ RSpec.describe "Category Groups", system: true do
   it "renders category badges" do
     visit "/categories"
 
-    expect(page).to have_css(".category-box-heading .d-icon-heart", count: 1)
-    expect(page).to have_css(".category-box-heading .--style-square", count: 2)
+    within(".custom-category-group-default-categories") do
+      expect(page).to have_css(".category-box-heading .d-icon-heart", count: 1)
+      expect(page).to have_css(".category-box-heading .--style-square", count: 1)
+    end
   end
 
   it "positions an extra link before its show_before category" do

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -22,11 +22,21 @@ RSpec.describe "Category Groups", system: true do
           "title" => title,
           "description" => description,
           "icon" => "heart",
+          "show_after" => [category.id],
         },
       ].to_json,
     )
     theme_component.update_setting(:fancy_styling, true)
-    theme_component.update_setting(:category_groups, "Default Categories: #{id}, #{category.slug}")
+    theme_component.update_setting(
+      :category_groups,
+      [
+        {
+          "name" => "Default Categories",
+          "categories" => [category.id],
+          "translations" => [{ "locale" => "fr", "name" => "Catégories par défaut" }],
+        },
+      ].to_json,
+    )
     SiteSetting.desktop_category_page_style = "categories_boxes"
     theme_component.save!
   end
@@ -62,6 +72,32 @@ RSpec.describe "Category Groups", system: true do
 
     expect(page).to have_css(".category-box-heading .d-icon-heart", count: 1)
     expect(page).to have_css(".category-box-heading .--style-square", count: 2)
+  end
+
+  it "positions an extra link after its show_after category" do
+    visit "/categories"
+
+    expect(page).to have_css(
+      ".custom-category-group-default-categories .category-box-#{category.slug} + .extra-link-#{id}",
+    )
+  end
+
+  it "displays the group name in the default locale" do
+    visit "/categories"
+
+    expect(page).to have_css(".custom-category-group-default-categories h2", text: "Default Categories")
+  end
+
+  it "localizes the group name for the user's locale" do
+    SiteSetting.allow_user_locale = true
+    sign_in(Fabricate(:admin, locale: "fr"))
+
+    visit "/categories"
+
+    expect(page).to have_css(
+      ".custom-category-group-default-categories h2",
+      text: "Catégories par défaut",
+    )
   end
 
   it "works with core category icons and emojis" do

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Category Groups", system: true do
           "title" => title,
           "description" => description,
           "icon" => "heart",
-          "show_after" => [category.id],
+          "show_before" => [category.id],
         },
       ].to_json,
     )
@@ -74,11 +74,11 @@ RSpec.describe "Category Groups", system: true do
     expect(page).to have_css(".category-box-heading .--style-square", count: 2)
   end
 
-  it "positions an extra link after its show_after category" do
+  it "positions an extra link before its show_before category" do
     visit "/categories"
 
     expect(page).to have_css(
-      ".custom-category-group-default-categories .category-box-#{category.slug} + .extra-link-#{id}",
+      ".custom-category-group-default-categories .extra-link-#{id} + .category-box-#{category.slug}",
     )
   end
 


### PR DESCRIPTION
This converts the existing settings to object type settings, which allows for a locale field so admins using this theme can provide translations for the group names. 

This also allows us to use the category selector so admins don't have to manually add category slugs. 


Before: 
<img width="672" height="276" alt="image" src="https://github.com/user-attachments/assets/9e78abd2-8a49-4b0d-b456-cc49b6c236d6" />


After:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d8da91b4-cb4e-43dc-870b-ec2a34d28615" />
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/5caac90f-e3bf-4548-a2a6-402d1e87fb1b" />



I also migrated the "extra_links" setting from schema to objects type. This also allows for more convenient use of the category field when positioning the extra links. Extra links are now positioned before a specific category, rather than being included by manually adding an ID to a text list. 