### PR TITLE
FEATURE: add group visibility setting

### DIFF
--- a/javascripts/discourse/components/categories-groups.gjs
+++ b/javascripts/discourse/components/categories-groups.gjs
@@ -10,10 +10,6 @@ import CategoryLogo from "discourse/components/category-logo";
 import CategoryTitleBefore from "discourse/components/category-title-before";
 import CategoryTitleLink from "discourse/components/category-title-link";
 import CdnImg from "discourse/components/cdn-img";
-import {
-  addUniqueValueToArray,
-  removeValueFromArray,
-} from "discourse/lib/array-tools";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import borderColor from "discourse/helpers/border-color";
 import categoryLink, {
@@ -21,6 +17,10 @@ import categoryLink, {
 } from "discourse/helpers/category-link";
 import icon from "discourse/helpers/d-icon";
 import lazyHash from "discourse/helpers/lazy-hash";
+import {
+  addUniqueValueToArray,
+  removeValueFromArray,
+} from "discourse/lib/array-tools";
 import { slugify } from "discourse/lib/utilities";
 import I18nInstance, { i18n } from "discourse-i18n";
 import CategoryGroupExtraLink from "./category-group-extra-link";
@@ -38,8 +38,21 @@ const ExtraLink = class {
 };
 
 export default class CategoriesGroups extends Component {
+  @service currentUser;
   @service router;
   @service siteSettings;
+
+  isVisibleToCurrentUser(group) {
+    const visibility = group.visibility || [];
+
+    if (visibility.length === 0 || visibility.includes(0)) {
+      return true;
+    }
+
+    return (this.currentUser?.groups || []).some((g) =>
+      visibility.includes(g.id)
+    );
+  }
 
   localizedGroupName(group) {
     const locale = I18nInstance.currentLocale();
@@ -99,7 +112,13 @@ export default class CategoriesGroups extends Component {
         )
         .filter(Boolean);
 
+      // Categories in a hidden group still count as grouped, so they don't
+      // reappear in the "ungrouped" section for users who can't see the group.
       groupCategories.forEach((c) => foundCategories.push(c.slug));
+
+      if (!this.isVisibleToCurrentUser(obj)) {
+        return groups;
+      }
 
       const items = withLinks(groupCategories);
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,9 +2,14 @@ en:
   theme_metadata:
     description: "custom category page with group settings"
     settings:
-      category_groups: "Define each group with a name and the categories it contains (in display order). Use the translations field to localize a group's name per locale (e.g. locale 'fr')."
+      category_groups:
+        description: "Define each group with a name and the categories it contains (in display order). Use the translations field to localize a group's name per locale (e.g. locale 'fr')."
+        schema:
+          properties:
+            visibility:
+              description: "Only members of these groups will see this category group on the categories page. Leave blank to show it to everyone. This only controls whether the group is displayed here — it does not change category permissions, and the categories remain visible everywhere else."
       extra_links:
-        description: "Extra links that can be mixed into the category list. Use \"show before\" to position a link before a category, or \"show in group\" to add it to the end of a group."
+        description: 'Extra links that can be mixed into the category list. Use "show before" to position a link before a category, or "show in group" to add it to the end of a group.'
         schema:
           properties:
             id:

--- a/settings.yml
+++ b/settings.yml
@@ -10,6 +10,8 @@ category_groups:
         required: true
       categories:
         type: categories
+      visibility:
+        type: groups
       translations:
         type: objects
         schema:

--- a/spec/system/custom_category_group_spec.rb
+++ b/spec/system/custom_category_group_spec.rb
@@ -156,6 +156,65 @@ RSpec.describe "Category Groups", system: true do
     end
   end
 
+  context "with visibility set on a group" do
+    let!(:restricted_group) { Fabricate(:group) }
+    let!(:other_category) { Fabricate(:category) }
+
+    def set_visibility(group_ids)
+      theme_component.update_setting(
+        :category_groups,
+        [
+          {
+            "name" => "Default Categories",
+            "categories" => [category.id],
+            "visibility" => group_ids,
+          },
+        ].to_json,
+      )
+      theme_component.save!
+    end
+
+    it "hides the group from users who aren't members" do
+      set_visibility([restricted_group.id])
+
+      visit "/categories"
+
+      expect(page).to have_css(".custom-categories-groups")
+      expect(page).to have_no_css(".custom-category-group-default-categories")
+    end
+
+    it "shows the group to members" do
+      user = Fabricate(:user)
+      restricted_group.add(user)
+      sign_in(user)
+      set_visibility([restricted_group.id])
+
+      visit "/categories"
+
+      expect(page).to have_css(".custom-category-group-default-categories")
+    end
+
+    it "shows the group to everyone when visibility is blank" do
+      sign_in(Fabricate(:user))
+      set_visibility([])
+
+      visit "/categories"
+
+      expect(page).to have_css(".custom-category-group-default-categories")
+    end
+
+    it "doesn't move the categories of a hidden group into the ungrouped section" do
+      set_visibility([restricted_group.id])
+
+      visit "/categories"
+
+      within(".custom-category-group-ungrouped") do
+        expect(page).to have_no_css(".category-box-#{category.slug}")
+        expect(page).to have_css(".category-box-#{other_category.slug}")
+      end
+    end
+  end
+
   it "works with core category icons and emojis" do
     category.update!(style_type: "emoji", emoji: "wave")
     visit "/categories"


### PR DESCRIPTION
This adds a new (optional) setting that allows individual category groups to be only visible to specific groups of users. Thanks to @gormus originally proposing this in https://github.com/discourse/discourse-category-groups-component/pull/51

The default for this setting is blank, which makes the group visible to everyone, so it will not impact existing users of the component. 